### PR TITLE
Several bugfixes (Search, OP Blocks tab)

### DIFF
--- a/Common/src/main/java/me/hypherionmc/morecreativetabs/mixin/accessors/CreativeModeTabAccessor.java
+++ b/Common/src/main/java/me/hypherionmc/morecreativetabs/mixin/accessors/CreativeModeTabAccessor.java
@@ -30,7 +30,7 @@ public interface CreativeModeTabAccessor {
     public Component getInternalDisplayName();
 
     @Accessor("displayItems")
-    public Collection<ItemStack> getDisplayItems();
+    public Collection<ItemStack> getDisplayItemsVariable();
 
     @Accessor("displayItemsSearchTab")
     public Set<ItemStack> getDisplayItemSearchTab();

--- a/Fabric/src/main/java/me/hypherionmc/morecreativetabs/client/FabricResourceLoader.java
+++ b/Fabric/src/main/java/me/hypherionmc/morecreativetabs/client/FabricResourceLoader.java
@@ -1,24 +1,17 @@
 package me.hypherionmc.morecreativetabs.client;
 
-import com.google.common.collect.ImmutableList;
 import me.hypherionmc.morecreativetabs.ModConstants;
 import me.hypherionmc.morecreativetabs.client.tabs.CustomCreativeTabRegistry;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.CreativeModeTabs;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-
-import static net.minecraft.world.item.CreativeModeTabs.*;
 
 /**
  * @author HypherionSA
@@ -36,17 +29,7 @@ public class FabricResourceLoader implements SimpleSynchronousResourceReloadList
     @Override
     public void onResourceManagerReload(@NotNull ResourceManager resourceManager) {
         if (!hasRun) {
-            List<ResourceKey<CreativeModeTab>> VANILLA_TABS = ImmutableList.of(BUILDING_BLOCKS, COLORED_BLOCKS, NATURAL_BLOCKS, FUNCTIONAL_BLOCKS, REDSTONE_BLOCKS, HOTBAR, SEARCH, TOOLS_AND_UTILITIES, COMBAT, FOOD_AND_DRINKS, INGREDIENTS, SPAWN_EGGS, INVENTORY);
-            List<CreativeModeTab> beforeTabs = new ArrayList<>();
-            VANILLA_TABS.forEach(t -> beforeTabs.add(BuiltInRegistries.CREATIVE_MODE_TAB.get(t)));
-            CreativeModeTab tab = BuiltInRegistries.CREATIVE_MODE_TAB.get(CreativeModeTabs.OP_BLOCKS);
-
-            BuiltInRegistries.CREATIVE_MODE_TAB.stream().toList().forEach(t -> {
-                if (t != tab && !beforeTabs.contains(t))
-                    beforeTabs.add(t);
-            });
-
-            CustomCreativeTabRegistry.tabs_before = beforeTabs;
+            CustomCreativeTabRegistry.tabs_before = new ArrayList<>(BuiltInRegistries.CREATIVE_MODE_TAB.stream().toList());
             reloadTabs();
             hasRun = true;
         } else {

--- a/Fabric/src/main/java/me/hypherionmc/morecreativetabs/client/TabPlatformHelper.java
+++ b/Fabric/src/main/java/me/hypherionmc/morecreativetabs/client/TabPlatformHelper.java
@@ -3,7 +3,6 @@ package me.hypherionmc.morecreativetabs.client;
 import me.hypherionmc.morecreativetabs.client.tabs.CustomCreativeTabRegistry;
 import me.hypherionmc.morecreativetabs.mixin.accessors.CreativeModeTabAccessor;
 import me.hypherionmc.morecreativetabs.platform.services.ITabHelper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.ItemStack;
@@ -20,18 +19,20 @@ public class TabPlatformHelper implements ITabHelper {
     @Override
     public void updateCreativeTabs(List<CreativeModeTab> tabs) {
         CreativeModeTabs.validate();
-        Minecraft.getInstance().createSearchTrees();
 
         Set<ItemStack> set = ItemStackLinkedSet.createTypeAndTagSet();
-        CreativeModeTabAccessor accessor = ((CreativeModeTabAccessor) CreativeModeTabs.searchTab());
+        CreativeModeTab searchTab = CreativeModeTabs.searchTab();
+        CreativeModeTabAccessor accessor = (CreativeModeTabAccessor) searchTab;
         for (CreativeModeTab t : CustomCreativeTabRegistry.current_tabs) {
             if (t.getType() != CreativeModeTab.Type.SEARCH) {
                 set.addAll(t.getSearchTabDisplayItems());
             }
         }
         accessor.getDisplayItemSearchTab().clear();
-        accessor.getDisplayItems().clear();
-        accessor.getDisplayItems().addAll(set);
+        accessor.getDisplayItemsVariable().clear();
+        accessor.getDisplayItemsVariable().addAll(set);
         accessor.getDisplayItemSearchTab().addAll(set);
+
+        searchTab.rebuildSearchTree();
     }
 }

--- a/Fabric/src/main/java/me/hypherionmc/morecreativetabs/mixin/FabricCreativeModeTabMixin.java
+++ b/Fabric/src/main/java/me/hypherionmc/morecreativetabs/mixin/FabricCreativeModeTabMixin.java
@@ -1,6 +1,7 @@
 package me.hypherionmc.morecreativetabs.mixin;
 
 import me.hypherionmc.morecreativetabs.client.tabs.CustomCreativeTabRegistry;
+import me.hypherionmc.morecreativetabs.platform.PlatformServices;
 import net.fabricmc.fabric.impl.itemgroup.FabricItemGroup;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
@@ -54,6 +55,7 @@ public abstract class FabricCreativeModeTabMixin {
         final CreativeModeTab self = (CreativeModeTab) (Object) this;
 
         if (self == CreativeModeTabs.searchTab()) {
+            PlatformServices.TAB_HELPER.updateCreativeTabs(CustomCreativeTabRegistry.current_tabs);
             ci.cancel();
             return;
         }

--- a/Forge/src/main/java/me/hypherionmc/morecreativetabs/MoreCreativeTabs.java
+++ b/Forge/src/main/java/me/hypherionmc/morecreativetabs/MoreCreativeTabs.java
@@ -1,15 +1,11 @@
 package me.hypherionmc.morecreativetabs;
 
-import com.google.common.collect.ImmutableList;
 import me.hypherionmc.morecreativetabs.client.tabs.CustomCreativeTabRegistry;
-import me.hypherionmc.morecreativetabs.mixin.accessor.ForgeCreativeModeTabRegistryAccessor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.IExtensionPoint;
@@ -17,10 +13,7 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-
-import static net.minecraft.world.item.CreativeModeTabs.*;
 
 /**
  * @author HypherionSA
@@ -36,18 +29,7 @@ public class MoreCreativeTabs {
 
     public static void reloadResources() {
         if (!hasRun) {
-            List<ResourceKey<CreativeModeTab>> VANILLA_TABS = ImmutableList.of(BUILDING_BLOCKS, COLORED_BLOCKS, NATURAL_BLOCKS, FUNCTIONAL_BLOCKS, REDSTONE_BLOCKS, HOTBAR, SEARCH, TOOLS_AND_UTILITIES, COMBAT, FOOD_AND_DRINKS, INGREDIENTS, SPAWN_EGGS, INVENTORY);
-            List<CreativeModeTab> beforeTabs = new ArrayList<>();
-            VANILLA_TABS.forEach(t -> beforeTabs.add(BuiltInRegistries.CREATIVE_MODE_TAB.get(t)));
-            CreativeModeTab tab = BuiltInRegistries.CREATIVE_MODE_TAB.get(OP_BLOCKS);
-
-            ForgeCreativeModeTabRegistryAccessor.getInternalTabs().forEach(t -> {
-                if (t != tab && !beforeTabs.contains(t)) {
-                    beforeTabs.add(t);
-                }
-            });
-
-            CustomCreativeTabRegistry.tabs_before = beforeTabs;
+            CustomCreativeTabRegistry.tabs_before = new ArrayList<>(BuiltInRegistries.CREATIVE_MODE_TAB.stream().toList());
             reloadTabs();
             hasRun = true;
         } else {

--- a/Forge/src/main/java/me/hypherionmc/morecreativetabs/client/ForgeTabHelper.java
+++ b/Forge/src/main/java/me/hypherionmc/morecreativetabs/client/ForgeTabHelper.java
@@ -21,15 +21,18 @@ public class ForgeTabHelper implements ITabHelper {
     public void updateCreativeTabs(List<CreativeModeTab> tabs) {
         //Minecraft.getInstance().createSearchTrees();
         Set<ItemStack> set = ItemStackLinkedSet.createTypeAndTagSet();
-        CreativeModeTabAccessor accessor = ((CreativeModeTabAccessor) CreativeModeTabs.searchTab());
+        CreativeModeTab searchTab = CreativeModeTabs.searchTab();
+        CreativeModeTabAccessor accessor = (CreativeModeTabAccessor) searchTab;
         for (CreativeModeTab t : CustomCreativeTabRegistry.current_tabs) {
             if (t.getType() != CreativeModeTab.Type.SEARCH) {
                 set.addAll(t.getSearchTabDisplayItems());
             }
         }
         accessor.getDisplayItemSearchTab().clear();
-        accessor.getDisplayItems().clear();
-        accessor.getDisplayItems().addAll(set);
+        accessor.getDisplayItemsVariable().clear();
+        accessor.getDisplayItemsVariable().addAll(set);
         accessor.getDisplayItemSearchTab().addAll(set);
+
+        searchTab.rebuildSearchTree();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project
 base_version=1.2
-version_patch=1
+version_patch=2
 group=me.hypherionmc.morecreativetabs
 
 # Common


### PR DESCRIPTION
This PR fixes:
- Search: Search appeared to be broke due to the search tree, which did not update correctly. The search tree also did not update immediately after startup without doing `/mct reloadTabs`, thats why the update function is called again after building the search tab. I've not tested all features, only added a new tab, which worked for me.
- OP Blocks Tab missing: The OP blocks tab was especially not shown regardless of the user setting. I don't know why this was done, but imo this tab is quite useful, thats why I re-added it.
- During testing I realized the `CreativeModeTabAccessor` somehow interfers with the mixins and therefore blocking the mixin for `getDisplayItems` (I guess only during testing, because it's not obfuscated there), so I renamed this method in order to fix the mixin during testing

Everything done for the fabric version. Don't know if those bugs exist on the forge version as well or if they are fixed now. I've made the same changes in the forge version as well, but was not able to test them.